### PR TITLE
"./regionalizer --help" concept introduced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+help.txt.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,21 @@ set(files
   DatabaseReader/DatabaseReader.cpp
 )
 
+######
+
+SET(RESOURCE_COMPILER xxd)
+  SET(INPUT_FILE "../help.txt")
+  SET(OUTPUT_FILE ${INPUT_FILE}.hpp)
+  ADD_CUSTOM_COMMAND(
+    OUTPUT ${OUTPUT_FILE}
+    COMMAND ${RESOURCE_COMPILER} -i ${INPUT_FILE} ${OUTPUT_FILE}
+    COMMENT "Compiling ${INPUT_FILE} (text file) to hpp")
+  LIST(APPEND COMPILED_RESOURCES ${OUTPUT_FILE})
+
+######
+
 project (regionalizer)
-add_executable(regionalizer main.cpp ${files}) 
+add_executable(regionalizer main.cpp ${files} ${COMPILED_RESOURCES}) 
 include_directories(${GTEST_INCLUDE_DIRS})
 target_link_libraries(regionalizer gtest pthread)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,13 +51,17 @@ set(files
 
 ######
 
-SET(RESOURCE_COMPILER xxd)
+  SET(RESOURCE_COMPILER xxd)
   SET(INPUT_FILE "../help.txt")
   SET(OUTPUT_FILE ${INPUT_FILE}.hpp)
+  #  ADD_CUSTOM_COMMAND(
+  #    OUTPUT ${OUTPUT_FILE}.test
+  #    COMMAND rm -f help.txt.hpp
+  #    COMMENT "Removing ${OUTPUT_FILE}")
   ADD_CUSTOM_COMMAND(
     OUTPUT ${OUTPUT_FILE}
     COMMAND ${RESOURCE_COMPILER} -i ${INPUT_FILE} ${OUTPUT_FILE}
-    COMMENT "Compiling ${INPUT_FILE} (text file) to hpp")
+    COMMENT "Compiling ${INPUT_FILE} (text file) to ${OUTPUT_FILE}")
   LIST(APPEND COMPILED_RESOURCES ${OUTPUT_FILE})
 
 ######

--- a/FlagParser/FlagParser.cpp
+++ b/FlagParser/FlagParser.cpp
@@ -85,6 +85,10 @@ void FlagParser::printFlags() {
     }
 }
 
+bool FlagParser::hasKey(std::string key) {
+    return (flags.find(key) == flags.end());
+}
+
 std::map<std::string, std::string> FlagParser::getFlags() {
     return flags;
 }

--- a/FlagParser/FlagParser.hpp
+++ b/FlagParser/FlagParser.hpp
@@ -26,6 +26,7 @@ class FlagParser {
     ~FlagParser();
     void parse(std::vector<std::string> vargv);
     void printFlags();
+    bool hasKey(std::string key);
     std::map<std::string, std::string> getFlags();
 };
 

--- a/help.txt
+++ b/help.txt
@@ -1,0 +1,23 @@
++-----------------------------------------------------------------------------+
+|                          R E G I O N A L I Z E R                            |
++-----------------------------------------------------------------------------+
+
+    USAGE:
+
+    ./regionalizer -list [path to database file]
+
+i.e.:
+    ./regionalizer -list ../database/file.txt
+
+    LIST OF ...:
+
+    -list [path to the database file]
+    
+    Parses the file and outputs TBD
+
+
+    --help
+
+    Prints this very manual and terminates
+
+

--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,17 @@ int main(int argc, char *argv[]) {
     parser.printFlags();
     auto flags = parser.getFlags();
 
+    if (flags.find("--help")  == flags.end()) {
+	std::cout << "Help not found, so moving on...";	
+	std::cout << std::endl;
+    } else {
+	std::cout << "Help found, so I am about to print help...";	
+	std::cout << std::endl;
+// TODO: print the content of help.txt
+	std::cout << "Aborting....";
+	std::cout << std::endl;
+	return -1;
+    }
     if (!flags["-list"].empty()) {
         std::cout << "Great! " << flags["-list"] << " is being processed";
 	std::cout << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]) {
     parser.printFlags();
     auto flags = parser.getFlags();
 
-    if (flags.find("--help")  == flags.end()) {
+    if (parser.hasKey("--help")) {
 	std::cout << "Help not found, so moving on...";	
 	std::cout << std::endl;
     } else {

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include "FlagParser.hpp"
 #include "DatabaseReader.hpp"
+#include "help.txt.hpp"
 
 int main(int argc, char *argv[]) {
     // Part 1 - start - parse argv and get databaseFile
@@ -13,7 +14,7 @@ int main(int argc, char *argv[]) {
     } else {
 	std::cout << "Help found, so I am about to print help...";	
 	std::cout << std::endl;
-// TODO: print the content of help.txt
+        std::cout << ___help_txt;
 	std::cout << "Aborting....";
 	std::cout << std::endl;
 	return -1;
@@ -27,7 +28,7 @@ int main(int argc, char *argv[]) {
 	std::cout << "Aborting....";
 	std::cout << std::endl;
 	return -1;
-    }
+    } 
 
     std::string databaseFile{flags["-list"]};
     // Part 1 - end


### PR DESCRIPTION
Basic concept introduced.

I think we could merge it for now
...and quickly we should implement unit test for different argv

...and also "the parsing process" should be moved from `main.cpp` to somewhere else. Perhaps FlagParser class could be a good option. But maybe new file for flag handling would be better.
In fact, I think we should separate:

1. `FlagParser` - logic of argv processing. This class gives us `std::map flags`
2. `FlagHandling` - here we could process the `flags` object. i.e. when `--help` is given: print `help.txt` and terminate the program(application)

...I am not sure if this is good idea... I would like to know your opinion on that, @kermit10000000 